### PR TITLE
add support for additional parameters to be passed to the docker run cmd.

### DIFF
--- a/lib/vocker/docker_client.rb
+++ b/lib/vocker/docker_client.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
       def create_container(config)
         args = "-cidfile=#{config[:cidfile]} -d"
         args << " -dns=#{config[:dns]}" if config[:dns]
+        args << " #{config[:additional_run_args]}" if config[:additional_run_args]
         @machine.communicate.sudo %[
           rm -f #{config[:cidfile]}
           docker run #{args} #{config[:image]} #{config[:cmd]}

--- a/spec/unit/docker_client_spec.rb
+++ b/spec/unit/docker_client_spec.rb
@@ -56,6 +56,13 @@ describe VagrantPlugins::Vocker::DockerClient do
       expect(communicator).to have_received.sudo(with{|cmd| cmd =~ /-dns=127\.0\.0\.1/})
     end
 
+    it 'allows additional params to be passed to the run command if specified' do
+      stub(communicator).test(with{|cmd| cmd =~ /docker ps/}) { false }
+      containers['mysql'][:additional_run_args] = '-p 49176:5601 -p 49175:514'
+      subject.run containers
+      expect(communicator).to have_received.sudo(with{|cmd| cmd =~ /-p 49176:5601 -p 49175:514/})
+    end
+
     context 'when the container already exists' do
       before do
         stub(communicator).test(with{|cmd| cmd =~ /docker ps -a -q/}) { true }


### PR DESCRIPTION
I was basically trying to run a additional docker package that starts the ports on randomly exposed container ports. I want to start the run command and tell it which ports to assign so I can have another docker container connect to them in a predictable manner.

This is the expected usage inside the vagrant file
          logstash: { image: 'ehazlett/logstash', additional_run_args: '-p 49176:5601 -p 49175:514', cmd: '/usr/local/bin/run'}

this will allow users to pass arbitrary arguments to the docker run command. Another option would be to support a more specific arg like port: but since it can be passed multiple times and there are other options people might want to use I thought that a generic arg might make more sense.
