### PR TITLE
Use configured ssh username

### DIFF
--- a/lib/vocker/cap/debian/docker_configure_vagrant_user.rb
+++ b/lib/vocker/cap/debian/docker_configure_vagrant_user.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         module DockerConfigureVagrantUser
           def self.docker_configure_vagrant_user(machine)
             # FIXME: We should make use of the config.ssh.username here
-            machine.communicate.sudo("usermod -a -G docker vagrant")
+            machine.communicate.sudo("usermod -a -G docker #{machine.config.ssh.username || "vagrant"}")
           end
         end
       end


### PR DESCRIPTION
If no configured user is provided, will use "vagrant" by default. Does `config.ssh.username` get set to "vagrant" automatically? If so, we can take the conditional out.
